### PR TITLE
refactor: require artifacts

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -141,7 +141,9 @@ The Actor-Critic system provides several tools that the AI agent can use:
 - `resume`: Fetches recent context for a branch
 - `export_plan`: Exports the current graph, optionally filtered by tag
 - `summarize_branch`: Generates a summary for a specific branch
-  ...
+- `list_projects`: Lists all available knowledge graph projects
+- `switch_project`: Switches to a different knowledge graph project
+- `create_project`: Creates a new knowledge graph project
 
 ### Actor-Critic Workflow
 
@@ -157,6 +159,29 @@ The actor-critic system follows this workflow:
    - `reject`: The node is fundamentally flawed or has reached max revision attempts
 
 **Important Note**: In most cases, you don't need to call `critic_review` directly as it's automatically triggered by `actor_think` when appropriate. The `critic_review` tool is primarily useful for manual intervention, forcing a review of a specific previous node, or debugging purposes.
+
+### Project Management
+
+The Actor-Critic system supports working with multiple knowledge graph projects, each with its own separate context:
+
+1. **Listing Projects**:
+
+   ```
+   Use the list_projects tool to see all available projects
+   ```
+
+2. **Switching Projects**:
+
+   ```
+   Use the switch_project tool to switch to the "my-feature" project
+   ```
+
+3. **Creating a New Project**:
+   ```
+   Use the create_project tool to create a new project called "new-feature"
+   ```
+
+Project names must be alphanumeric with optional dashes and underscores, and have a maximum length of 50 characters. Each project maintains its own separate knowledge graph, allowing you to work on different codebases or features without mixing contexts.
 
 ### Example Workflow
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -135,13 +135,28 @@ Use the actor critic tool to plan and implement a feature that...
 
 The Actor-Critic system provides several tools that the AI agent can use:
 
-- `actor_think`: Creates a new thought node in the knowledge graph
-- `critic_review`: Evaluates an actor node for quality and consistency
+- `actor_think`: Creates a new thought node in the knowledge graph (primary tool)
+- `critic_review`: Manually evaluates an actor node (rarely needed)
 - `list_branches`: Shows all branches in the knowledge graph
 - `resume`: Fetches recent context for a branch
 - `export_plan`: Exports the current graph, optionally filtered by tag
 - `summarize_branch`: Generates a summary for a specific branch
   ...
+
+### Actor-Critic Workflow
+
+The actor-critic system follows this workflow:
+
+1. The agent calls `actor_think` to add a new thought node to the knowledge graph
+2. The system automatically triggers a critic review when:
+   - A certain number of steps have been taken (configured by CRITIC_EVERY_N_STEPS)
+   - The actor indicates the thought doesn't need more work (needsMore=false)
+3. The critic evaluates the node and provides a verdict:
+   - `approved`: The node meets all requirements
+   - `needs_revision`: The node needs specific improvements
+   - `reject`: The node is fundamentally flawed or has reached max revision attempts
+
+**Important Note**: In most cases, you don't need to call `critic_review` directly as it's automatically triggered by `actor_think` when appropriate. The `critic_review` tool is primarily useful for manual intervention, forcing a review of a specific previous node, or debugging purposes.
 
 ### Example Workflow
 
@@ -168,17 +183,17 @@ The Actor-Critic system provides several tools that the AI agent can use:
 
 #### Agent Configuration Problems
 
-**Issue**: "Failed to parse JSON from uv mcp-server-fetch"  
+**Issue**: "Failed to parse JSON from uv mcp-server-fetch"
 **Solution**: Check that the agent configuration files are correctly set up and API keys are valid. You can run `fast-agent check` to verify from the agent directory.
 
 #### Python Environment Issues
 
-**Issue**: "No module named 'fast-agent-mcp'"  
+**Issue**: "No module named 'fast-agent-mcp'"
 **Solution**: Run `uv sync` in the agent directory to install dependencies.
 
 #### MCP Connection Problems
 
-**Issue**: MCP server not responding  
+**Issue**: MCP server not responding
 **Solution**: Ensure the MCP server is running with `npx -y tsx path/to/actor-critic-mcp/src`.
 
 ### Getting Help

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ High‑level flow: caller → MCP → KG + Actor/Critic loop
 - **Hot‑Context Stream**
   Only the freshest, highest‑value nodes return to the LLM to keep within token budgets.
 
+### Actor-Critic Workflow
+
+The actor-critic system follows this workflow:
+
+1. The agent calls `actor_think` to add a new thought node to the knowledge graph
+2. The system automatically triggers a critic review when:
+   - A certain number of steps have been taken (configured by CRITIC_EVERY_N_STEPS)
+   - The actor indicates the thought doesn't need more work (needsMore=false)
+3. The critic evaluates the node and provides a verdict:
+   - `approved`: The node meets all requirements
+   - `needs_revision`: The node needs specific improvements
+   - `reject`: The node is fundamentally flawed or has reached max revision attempts
+
+In most cases, you don't need to call `critic_review` directly as it's automatically triggered by `actor_think` when appropriate. The `critic_review` tool is primarily useful for manual intervention, forcing a review of a specific previous node, or debugging purposes.
+
 ## Current status
 
 See **[`notes/next_steps.md`](notes/next_steps.md)** for details

--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ The actor-critic system follows this workflow:
 
 In most cases, you don't need to call `critic_review` directly as it's automatically triggered by `actor_think` when appropriate. The `critic_review` tool is primarily useful for manual intervention, forcing a review of a specific previous node, or debugging purposes.
 
+### Project Management Tools
+
+The actor-critic system supports working with multiple knowledge graph projects:
+
+1. **`list_projects`**: Lists all available knowledge graph projects
+
+   - Returns the current active project and all available projects
+
+2. **`switch_project`**: Switches to a different knowledge graph project
+
+   - Parameter: `projectName` - Name of the project to switch to
+   - Project names must be alphanumeric with optional dashes/underscores
+
+3. **`create_project`**: Creates a new knowledge graph project
+   - Parameter: `projectName` - Name of the new project to create
+   - Same naming rules as `switch_project`
+
+These tools allow you to organize your work into separate projects, each with its own knowledge graph. This is useful for working on multiple codebases or features without mixing contexts.
+
 ## Current status
 
 See **[`notes/next_steps.md`](notes/next_steps.md)** for details

--- a/src/agents/Actor.ts
+++ b/src/agents/Actor.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { KnowledgeGraphManager, ArtifactRef, DagNode } from '../engine/KnowledgeGraph.ts';
 import { CFG } from '../config.ts';
+import { ActorThinkInput } from '../engine/ActorCriticEngine.ts';
 
 export type ThinkDecision = (typeof Actor.THINK_DECISION)[keyof typeof Actor.THINK_DECISION];
 
@@ -12,13 +13,9 @@ export class Actor {
   };
   constructor(private readonly kg: KnowledgeGraphManager) {}
 
-  async think(input: {
-    thought: string;
-    needsMore?: boolean;
-    branchLabel?: string;
-    tags: string[];
-    artifacts?: Partial<ArtifactRef>[];
-  }): Promise<{ node: DagNode; decision: ThinkDecision }> {
+  async think(
+    input: ActorThinkInput & { artifacts?: Partial<ArtifactRef>[] },
+  ): Promise<{ node: DagNode; decision: ThinkDecision }> {
     const { thought, needsMore, branchLabel, tags, artifacts } = input;
 
     const parents = this.kg.getHeads().map((h) => h.id);

--- a/src/agents/Critic.ts
+++ b/src/agents/Critic.ts
@@ -2,7 +2,7 @@ import { execa } from 'execa';
 import { to } from 'await-to-js';
 import { v4 as uuid } from 'uuid';
 import { KnowledgeGraphManager, DagNode } from '../engine/KnowledgeGraph.ts';
-import { RevisionCounter } from '../actor-critic/RevisionCounter.ts';
+import { RevisionCounter } from '../engine/RevisionCounter.ts';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
@@ -99,6 +99,8 @@ export class Critic {
       target: actorNodeId,
       parents: [actorNodeId],
       children: [],
+      tags: [],
+      artifacts: [],
       needsMore: false,
       createdAt: new Date().toISOString(),
     };

--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -212,35 +212,22 @@ export class SummarizationAgent {
       }
     }
 
-    // If there are nodes to summarize, create a summary
-    if (nodesToSummarize.length > 0) {
-      console.log(`[summarizeBranch] Summarizing ${nodesToSummarize.length} nodes`);
-      try {
-        const summaryNode = await this.createSummary(nodesToSummarize);
-        return {
-          summary: summaryNode,
-          success: true,
-        };
-      } catch (error) {
-        console.error(`[summarizeBranch] Error creating summary:`, error);
-        return {
-          summary: null,
-          success: false,
-          errorCode: 'SUMMARIZATION_ERROR',
-          errorMessage: 'Error occurred during summarization process',
-          details: error instanceof Error ? error.message : String(error),
-        };
-      }
+    try {
+      const summaryNode = await this.createSummary(nodesToSummarize);
+      return {
+        summary: summaryNode,
+        success: true,
+      };
+    } catch (error) {
+      console.error(`[summarizeBranch] Error creating summary:`, error);
+      return {
+        summary: null,
+        success: false,
+        errorCode: 'SUMMARIZATION_ERROR',
+        errorMessage: 'Error occurred during summarization process',
+        details: error instanceof Error ? error.message : String(error),
+      };
     }
-
-    // If we reach here, all nodes have already been summarized
-    return {
-      summary: null,
-      success: false,
-      errorCode: 'ALREADY_SUMMARIZED',
-      errorMessage: 'All nodes in this branch have already been summarized',
-      details: `Branch has ${existingSummaries.length} summaries covering all summarizable nodes`,
-    };
   }
 
   /**
@@ -279,6 +266,7 @@ export class SummarizationAgent {
       createdAt: new Date().toISOString(),
       summarizedSegment: nodes.map((node) => node.id),
       tags: ['summary'],
+      artifacts: [],
     };
 
     console.log(`[createSummary] Created summary node with ID ${summaryNode.id}`);

--- a/src/engine/ActorCriticEngine.ts
+++ b/src/engine/ActorCriticEngine.ts
@@ -71,6 +71,17 @@ export class ActorCriticEngine {
     private readonly summarizationAgent: SummarizationAgent,
   ) {}
   /* --------------------------- public API --------------------------- */
+  /**
+   * Adds a new thought node to the knowledge graph and automatically triggers
+   * critic review when appropriate.
+   *
+   * The critic review is automatically triggered when:
+   * 1. A certain number of steps have been taken (configured by CRITIC_EVERY_N_STEPS)
+   * 2. The actor indicates the thought doesn't need more work (needsMore=false)
+   *
+   * @param input The actor thought input
+   * @returns Either the actor node (if no review was triggered) or the critic node (if review was triggered)
+   */
   async actorThink(input: ActorThinkInput): Promise<DagNode> {
     const { node, decision } = await this.actor.think(input);
 
@@ -81,6 +92,20 @@ export class ActorCriticEngine {
     return node;
   }
 
+  /**
+   * Manually triggers a critic review for a specific actor node.
+   *
+   * NOTE: In most cases, you don't need to call this directly as actorThink
+   * automatically triggers critic reviews when appropriate.
+   *
+   * This method is primarily useful for:
+   * - Manual intervention in the workflow
+   * - Forcing a review of a specific previous node
+   * - Debugging or testing purposes
+   *
+   * @param actorNodeId The ID of the actor node to review
+   * @returns The critic node
+   */
   async criticReview(actorNodeId: string): Promise<DagNode> {
     const criticNode = await this.critic.review(actorNodeId);
 

--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -34,6 +34,7 @@ describe('KnowledgeGraphManager', () => {
       children: [],
       createdAt: new Date().toISOString(),
       tags: ['test'],
+      artifacts: [],
     };
   }
 
@@ -42,6 +43,9 @@ describe('KnowledgeGraphManager', () => {
     return {
       id: uuid(),
       name: `Test artifact ${uuid().slice(0, 8)}`,
+      path: `test/path/${uuid().slice(0, 8)}`,
+      hash: uuid().slice(0, 8),
+      contentType: 'text/plain',
     };
   }
 

--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import { v4 as uuid } from 'uuid';
 import { CFG } from '../config.ts';
 import { ProjectManager } from './ProjectManager.ts';
+import { ActorThinkInput, FileRef } from './ActorCriticEngine.ts';
 
 // -----------------------------------------------------------------------------
 // Minimal JSON‑file Knowledge Graph adapter ------------------------------------
@@ -14,15 +15,11 @@ export interface BranchHead {
   depth: number;
 }
 
-export interface ArtifactRef {
+export interface ArtifactRef extends FileRef {
   id: string; // uuid for KG reference
-  name: string; // human label ("UML‑AuthSeq")
-  uri?: string; // optional external link or S3 key
-  contentType?: string; // mime‑type hint (image/png, text/markdown …)
-  hash?: string; // sha256 etc. (optional)
 }
 
-export interface DagNode {
+export interface DagNode extends ActorThinkInput {
   id: string;
   thought: string;
   role: 'actor' | 'critic' | 'summary';
@@ -32,11 +29,7 @@ export interface DagNode {
   target?: string; // nodeId this criticises
   parents: string[];
   children: string[];
-  needsMore?: boolean;
   createdAt: string; // ISO timestamp for durability
-  branchLabel?: string; // friendly label for this branch head
-  tags?: string[]; // free‑form categories ("design", "task", …)
-  artifacts?: ArtifactRef[]; // attached artefacts
   summarizedSegment?: string[]; // IDs of the nodes that were summarized (for summary nodes)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,6 @@ import { Critic, CriticSchema } from './agents/Critic.ts';
 import { RevisionCounter } from './engine/RevisionCounter.ts';
 import { Actor } from './agents/Actor.ts';
 import { SummarizationAgent } from './agents/Summarize.ts';
-import { CFG } from './config.ts';
-
-//TODO:
-// now that components are refactored...
-// 1 by 1 improve each component based on the temporal difference problems
-// additionally create new components needed to solve the problems
 
 // -----------------------------------------------------------------------------
 // MCP Server -------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,31 @@ async function main() {
 
   const server = new McpServer({ name: 'actor-critic-mcp', version: '0.4.0' });
 
-  server.tool('actor_think', ActorThinkSchema, async (args) => ({
+  const ACTOR_THINK_DESCRIPTION = `
+  Add a new thought node to the knowledge‑graph.
+
+  • Use for any creative / planning step, requirement capture, task break‑down, etc.
+  • **Always include at least one semantic 'tag'** so future searches can find this node
+    – e.g. requirement, task, risk, design, definition.
+  • **If your thought references a file you just created or modified**, list it in the 'artifacts' array.
+  • Use 'branchLabel' **only** on the first node of an alternative approach.
+  • Think of 'tags' + 'artifacts' as the breadcrumbs that future you (or another
+    agent) will follow to avoid duplicate work or forgotten decisions.
+  *
+  `;
+
+  /**
+   * actor_think - Add a new thought node to the knowledge graph.
+   *
+   * This is the primary tool for interacting with the actor-critic system.
+   * It automatically triggers critic reviews when appropriate, so you don't
+   * need to call critic_review separately in most cases.
+   *
+   * The response will include:
+   * - The actor node if no critic review was triggered
+   * - The critic node if a review was automatically triggered
+   */
+  server.tool('actor_think', ACTOR_THINK_DESCRIPTION, ActorThinkSchema, async (args) => ({
     content: [{ type: 'text', text: JSON.stringify(await engine.actorThink(args), null, 2) }],
   }));
 
@@ -45,8 +69,17 @@ async function main() {
   // -----------------------------------------------------------------------------
 
   /**
-   * critic_review – evaluates an actor node. Call after every ~3 actor steps,
-   * or sooner if the agent is uncertain.
+   * critic_review – manually evaluates an actor node.
+   *
+   * NOTE: In most cases, you don't need to call this directly.
+   * The actor_think function automatically triggers critic reviews when:
+   * 1. A certain number of steps have been taken (configured by CRITIC_EVERY_N_STEPS)
+   * 2. The actor indicates the thought doesn't need more work (needsMore=false)
+   *
+   * This tool is primarily useful for:
+   * - Manual intervention in the workflow
+   * - Forcing a review of a specific previous node
+   * - Debugging or testing purposes
    */
   server.tool('critic_review', CriticSchema, async (a) => ({
     content: [


### PR DESCRIPTION
- refactor: improve type safety and standardize knowledge…
- refactor(types): create proper Zod schema for ActorThinkInput
- refactor(interfaces): standardize FileRef interface and make ArtifactRef extend from it
- refactor(model): make DagNode extend from ActorThinkInput for consistency
- fix(critic): add required tags and artifacts arrays to critic nodes
- fix(summarize): add required artifacts field to summary nodes
- refactor(summarize): simplify summarizeBranch method by removing redundant conditionals
- fix(imports): update RevisionCounter import path
- test(kg): improve test cases with required fields in fixtures
- chore: remove TODO comments from index.ts
- feat(docs): add project tool docs