### PR TITLE
refactor: simplify export functionality by removing filterTag

### DIFF
--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -276,12 +276,10 @@ export class KnowledgeGraphManager {
 
   async export({
     project,
-    filterTag,
     filterFn,
     limit,
   }: {
     project: string;
-    filterTag?: string;
     filterFn?: (node: DagNode) => boolean;
     limit?: number;
   }): Promise<DagNode[]> {
@@ -292,7 +290,6 @@ export class KnowledgeGraphManager {
       for await (const line of rl) {
         const node = this.parseDagNode(line);
         if (!node || node.project !== project) continue;
-        if (filterTag && !node.tags?.includes(filterTag)) continue;
         if (filterFn && !filterFn(node)) continue;
         nodes.push(node);
         if (limit && nodes.length >= limit) nodes.shift();

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,19 +203,15 @@ async function main() {
     {
       limit: z.number().optional().describe('Limit the number of nodes returned.'),
       projectContext: z.string().describe('Full path to the project directory.'),
-      filterTag: z.string().optional().describe('Return only nodes containing this tag.'),
     },
     async (a) => {
       const projectName = await loadProjectOrThrow({ logger, kg, args: a, onProjectLoad: runOnce });
+      const nodes = await kg.export({ project: projectName, limit: a.limit });
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(
-              kg.export({ project: projectName, filterTag: a.filterTag, limit: a.limit }),
-              null,
-              2,
-            ),
+            text: JSON.stringify(nodes, null, 2),
           },
         ],
       };


### PR DESCRIPTION
- Remove filterTag parameter from KnowledgeGraphManager.export
- Update export tool to use filterFn for node filtering
- Simplify export tool response by directly returning node data