### PR TITLE
feat: disable logging in unit tests

### DIFF
--- a/src/engine/KnowledgeGraph.test.ts
+++ b/src/engine/KnowledgeGraph.test.ts
@@ -5,7 +5,9 @@ import * as fsSync from 'node:fs';
 import path from 'node:path';
 import { v4 as uuid } from 'uuid';
 import os from 'node:os';
-import { getInstance as getLogger } from '../logger.js';
+import { createLogger, setGlobalLogger, getInstance as getLogger } from '../logger.js';
+const logger = createLogger({ withFile: false, withDevStdout: true });
+setGlobalLogger(logger);
 
 describe('KnowledgeGraphManager', () => {
   let kg: KnowledgeGraphManager;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,6 +11,7 @@ let globalLogger: CodeLoopsLogger | null = null;
 
 interface CreateLoggerOptions {
   withDevStdout?: boolean;
+  withFile?: boolean;
   sync?: boolean;
   setGlobal?: boolean;
 }
@@ -26,8 +27,9 @@ if (!fs.existsSync(logsDir)) {
  */
 export function createLogger(options?: CreateLoggerOptions): CodeLoopsLogger {
   // Ensure logs directory exists
-  const targets: pino.TransportTargetOptions[] = [
-    {
+  const targets: pino.TransportTargetOptions[] = [];
+  if (options?.withFile) {
+    targets.push({
       target: 'pino-roll',
       options: {
         file: logFile,
@@ -37,8 +39,8 @@ export function createLogger(options?: CreateLoggerOptions): CodeLoopsLogger {
           count: 14, // 14 days of log retention
         },
       },
-    },
-  ];
+    });
+  }
   if (options?.withDevStdout) {
     targets.push({
       target: 'pino-pretty',
@@ -63,7 +65,7 @@ export function createLogger(options?: CreateLoggerOptions): CodeLoopsLogger {
  */
 export function getInstance(options?: CreateLoggerOptions): CodeLoopsLogger {
   if (!globalLogger) {
-    createLogger({ ...options, setGlobal: true });
+    createLogger({ withFile: true, ...options, setGlobal: true });
   }
   return globalLogger!;
 }


### PR DESCRIPTION
Summary

* Modified src/engine/KnowledgeGraph.test.ts to update logger usage in tests, enabling more flexible logger configuration.
* Refactored src/logger.ts to support withFile and withDevStdout options, improved transport handling, and ensured the global logger uses file logging by default.