### PR TITLE
fix: json output and artifacts schema

### DIFF
--- a/src/agents/Summarize.ts
+++ b/src/agents/Summarize.ts
@@ -49,7 +49,7 @@ export class SummarizationAgent {
 
       // Call the Python agent using execa
       const [execError, output] = await to(
-        execa(this.pythonCommand, [...this.pythonArgs, 'agent.py', '--summarize'], {
+        execa(this.pythonCommand, [...this.pythonArgs, 'agent.py', '--quiet', '--summarize'], {
           cwd: this.agentPath,
           input: nodesJson,
         }),


### PR DESCRIPTION


Change summary: 
1. In src/agents/Summarize.ts, the execa call now includes the --quiet flag for cleaner operation.
2. In src/engine/KnowledgeGraph.ts, the DagNodeSchema was moved to a top-level export and all references updated, improving organization and reusability.

Big thanks to @piedol for putting in the time to hunt down the above fixes. I lifted the fixes from the PR submitted here: https://github.com/silvabyte/codeloops/pull/32 