### PR TITLE
feat: add diff control options to resume command

### DIFF
--- a/src/engine/KnowledgeGraph.ts
+++ b/src/engine/KnowledgeGraph.ts
@@ -213,8 +213,31 @@ export class KnowledgeGraphManager {
     return nodes;
   }
 
-  async resume({ project, limit = 5 }: { project: string; limit?: number }): Promise<DagNode[]> {
-    return this.export({ project, limit });
+  async resume({ 
+    project, 
+    limit = 5, 
+    includeDiffs = 'latest' 
+  }: { 
+    project: string; 
+    limit?: number;
+    includeDiffs?: 'all' | 'latest' | 'none';
+  }): Promise<DagNode[]> {
+    const nodes = await this.export({ project, limit });
+    
+    // Handle diff inclusion based on includeDiffs parameter
+    if (includeDiffs === 'none') {
+      // Remove diff from all nodes
+      return nodes.map(node => ({ ...node, diff: undefined }));
+    } else if (includeDiffs === 'latest') {
+      // Only include diff for the most recent node (last in array)
+      return nodes.map((node, index) => ({
+        ...node,
+        diff: index === nodes.length - 1 ? node.diff : undefined
+      }));
+    }
+    
+    // includeDiffs === 'all' - return nodes as is with all diffs
+    return nodes;
   }
 
   async export({

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -182,6 +182,11 @@ export const registerTools = ({ server }: { server: McpServer }) => {
         .number()
         .optional()
         .describe('Limit the number of nodes returned. Increase it if you need more context.'),
+      includeDiffs: z
+        .enum(['all', 'latest', 'none'])
+        .optional()
+        .default('latest')
+        .describe('Control diff inclusion: "all" includes all diffs, "latest" includes only the most recent diff, "none" excludes all diffs. Defaults to "latest" to avoid context overflow.'),
     },
     async (a) => {
       const { logger, kg, runOnce } = await getDeps();
@@ -189,6 +194,7 @@ export const registerTools = ({ server }: { server: McpServer }) => {
       const text = await kg.resume({
         project: projectName,
         limit: a.limit,
+        includeDiffs: a.includeDiffs || 'latest',
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(text, null, 2) }],


### PR DESCRIPTION
## Summary
Enhances the resume command to provide flexible control over diff inclusion to prevent context window overflow.

## Changes
- **Add `includeDiffs` parameter** to resume method with three options:
  - `'latest'` (default): Only include diff for the most recent node
  - `'none'`: Exclude all diffs entirely
  - `'all'`: Include all diffs (original behavior)
- **Prevent context overflow**: Default behavior now only shows the most recent diff
- **Backward compatible**: Existing code continues to work with safer defaults
- **Type safe**: Proper TypeScript interfaces and Zod validation

## Test plan
- [x] Verify TypeScript compilation passes
- [x] Test resume with `includeDiffs: 'none'` - confirms diffs are excluded
- [x] Test resume with default behavior - confirms only latest diff included
- [x] Test resume with `includeDiffs: 'all'` - confirms all diffs included

🤖 Generated with [Claude Code](https://claude.ai/code)